### PR TITLE
Support for short-circuit operators for BaseCriteria

### DIFF
--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -496,7 +496,7 @@
         
         public static bool operator true(BaseCriteria statement)
         {
-            return true;
+            return false;
         }
         
         public static bool operator false(BaseCriteria statement)

--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -18,7 +18,7 @@
         {
             get { return false; }
         }
-
+        
         public BaseCriteria IsNull()
         {
             return new UnaryCriteria(CriteriaOperator.IsNull, this);
@@ -493,7 +493,17 @@
                 return new UnaryCriteria(CriteriaOperator.Paren, criteria);
             return criteria;
         }
-
+        
+        public static bool operator true(BaseCriteria statement)
+        {
+            return true;
+        }
+        
+        public static bool operator false(BaseCriteria statement)
+        {
+            return false;
+        }
+        
         /// <summary>
         /// Must override this or will get operator overload warning.
         /// </summary>

--- a/Serenity.Test/Data/CriteriaEnumTests.cs
+++ b/Serenity.Test/Data/CriteriaEnumTests.cs
@@ -138,5 +138,60 @@ namespace Serenity.Test.Data
             Assert.IsType(typeof(MyEnum), value.Value);
             Assert.Equal(MyEnum.Value1, value.Value);
         }
+        
+        [Fact]
+        public void BaseCriteria_ShortCircuitAnd()
+        {
+            var left = new Criteria("x");
+            var actual = left == MyEnum.Value1;
+
+            Assert.NotNull(actual);
+            Assert.IsType(typeof(BinaryCriteria), actual);
+
+            var binary = actual as BinaryCriteria;
+
+            Assert.Equal(CriteriaOperator.EQ, binary.Operator);
+            Assert.Equal(binary.LeftOperand, left);
+            Assert.IsType(typeof(ValueCriteria), binary.RightOperand);
+
+            var value = binary.RightOperand as ValueCriteria;
+
+            Assert.IsType(typeof(MyEnum), value.Value);
+            Assert.Equal(MyEnum.Value1, value.Value);
+            var test1 = (MyEnum)value.Value == MyEnum.Value1 && (MyEnum)value.Value == MyEnum.Value1 && (MyEnum)value.Value == MyEnum.Value1;
+            Assert.True(test1);
+            var test2 = (MyEnum)value.Value == MyEnum.Value1 && (MyEnum)value.Value != MyEnum.Value1 && (MyEnum)value.Value == MyEnum.Value1;
+            Assert.False(test2);
+        }
+
+        [Fact]
+        public void BaseCriteria_ShortCircuitOr()
+        {
+            var left = new Criteria("x");
+            var actual = left == MyEnum.Value1;
+
+            Assert.NotNull(actual);
+            Assert.IsType(typeof(BinaryCriteria), actual);
+
+            var binary = actual as BinaryCriteria;
+
+            Assert.Equal(CriteriaOperator.EQ, binary.Operator);
+            Assert.Equal(binary.LeftOperand, left);
+            Assert.IsType(typeof(ValueCriteria), binary.RightOperand);
+
+            var value = binary.RightOperand as ValueCriteria;
+
+            Assert.IsType(typeof(MyEnum), value.Value);
+            Assert.Equal(MyEnum.Value1, value.Value);
+            var test = left != MyEnum.Value1 || left == MyEnum.Value1;
+            Assert.NotNull(test);
+
+            var test1 = (MyEnum)value.Value == MyEnum.Value1 || (MyEnum)value.Value != MyEnum.Value1 || (MyEnum)value.Value == MyEnum.Value1;
+            Assert.True(test1);
+            var test2 = (MyEnum)value.Value != MyEnum.Value1 || (MyEnum)value.Value != MyEnum.Value1 || (MyEnum)value.Value != MyEnum.Value1;
+            Assert.False(test2);
+            var test3 = (MyEnum)value.Value == MyEnum.Value1 || (MyEnum)value.Value == MyEnum.Value1 || (MyEnum)value.Value == MyEnum.Value1;
+            Assert.True(test3);
+        }
     }
 }


### PR DESCRIPTION
https://msdn.microsoft.com/en-us/library/93z43h7f%28v=vs.140%29.aspx

Operators `true` and `false` must be overloaded to be able to use the short circuit operators `&&` and `||`