### PR TITLE
Removed .s-Form .ui-datepicker-trigger

### DIFF
--- a/Serenity.Web/Style/serenity.form.less
+++ b/Serenity.Web/Style/serenity.form.less
@@ -53,12 +53,6 @@
     float: left;
 }
 
-.s-Form .ui-datepicker-trigger {
-    display: block;
-    float: left;
-    margin: 1px 0 0 1px;
-}
-
 .s-Form .separator {
     display: block;
     float: left;


### PR DESCRIPTION
This is causing the datepicker icons on a dialog form to float to the left instead of next to the respective textboxes.
So it renders as 'FromIcon ToIcon FromTextbox ToTextbox'
Removing this section and it renders 'FromTextbox FromIcon ToTextbox ToIcon' as it would on the main grid form.