### PR TITLE
Added DisplayProperty and UrlProperty to UrlFormatter

### DIFF
--- a/Serenity.Core/ComponentModel/Columns/Formatting/BasicFormatterTypes.cs
+++ b/Serenity.Core/ComponentModel/Columns/Formatting/BasicFormatterTypes.cs
@@ -130,5 +130,17 @@ namespace Serenity.ComponentModel
             : base("Url")
         {
         }
+        
+        public String DisplayProperty
+        {
+            get { return GetOption<String>("displayColumn"); }
+            set { SetOption("displayColumn", value); }
+        }
+
+        public String UrlProperty
+        {
+            get { return GetOption<String>("urlProperty"); }
+            set { SetOption("urlProperty", value); }
+        }
     }
 }

--- a/Serenity.Script.Core/SlickGrid/Formatters/UrlFormatter.cs
+++ b/Serenity.Script.Core/SlickGrid/Formatters/UrlFormatter.cs
@@ -4,9 +4,18 @@
     {
         public string Format(SlickFormatterContext ctx)
         {
-            return "<a href='" + Q.HtmlEncode(ctx.Value) + "'>" +
-                Q.HtmlEncode(ctx.Value) +
+            var display = !string.IsNullOrEmpty(DisplayProperty) ?
+                ctx.Item[DisplayProperty] as string : ctx.Value;
+            var url = !string.IsNullOrEmpty(UrlProperty) ?
+                ctx.Item[UrlProperty] as string : ctx.Value;
+            return "<a href='" + url + "'>" +
+                display +
                 "</a>";
         }
+
+        [Option]
+        public string DisplayProperty { get; set; }
+        [Option]
+        public string UrlProperty { get; set; }
     }
 }

--- a/Serenity.Script.Core/SlickGrid/Formatters/UrlFormatter.cs
+++ b/Serenity.Script.Core/SlickGrid/Formatters/UrlFormatter.cs
@@ -1,4 +1,6 @@
-﻿namespace Serenity
+using Serenity.ComponentModel;
+
+namespace Serenity
 {
     public class UrlFormatter : ISlickFormatter
     {
@@ -8,8 +10,8 @@
                 ctx.Item[DisplayProperty] as string : ctx.Value;
             var url = !string.IsNullOrEmpty(UrlProperty) ?
                 ctx.Item[UrlProperty] as string : ctx.Value;
-            return "<a href='" + url + "'>" +
-                display +
+            return "<a href='" + Q.HtmlEncode(url) + "'>" +
+                Q.HtmlEncode(display) +
                 "</a>";
         }
 

--- a/Serenity.Web/Style/serenity.form.less
+++ b/Serenity.Web/Style/serenity.form.less
@@ -53,12 +53,6 @@
     float: left;
 }
 
-.s-Form .ui-datepicker-trigger {
-    display: block;
-    float: left;
-    margin: 1px 0 0 1px;
-}
-
 .s-Form .separator {
     display: block;
     float: left;

--- a/Serenity.Web/Style/serenity.form.less
+++ b/Serenity.Web/Style/serenity.form.less
@@ -53,6 +53,12 @@
     float: left;
 }
 
+.s-Form .ui-datepicker-trigger {
+    display: block;
+    float: left;
+    margin: 1px 0 0 1px;
+}
+
 .s-Form .separator {
     display: block;
     float: left;


### PR DESCRIPTION
This allows you to optionally specify the column which contains the target URL and/or the link text for the UrlFormatter. Current version uses ctx.Value for both.