### PR TITLE
Delete "else" statement in "ExecuteSave()" method

### DIFF
--- a/Serenity.Services/RequestHandlers/Save/SaveRequestHandler.cs
+++ b/Serenity.Services/RequestHandlers/Save/SaveRequestHandler.cs
@@ -77,10 +77,7 @@ namespace Serenity.Services
                         update.Where(idField == new ValueCriteria(idField.AsObject(Old)));
                         update.Execute(Connection, ExpectedRows.One);
                     }
-                    else
-                    {
-                        Connection.UpdateById(Row);
-                    }
+                    
 
                     Connection.UpdateById(Row);
                     Response.EntityId = idField.AsObject(Row);


### PR DESCRIPTION
The "else" statement is unnecessary. "Connection.UpdateById(Row);" gets executed 2 times (2 Database access)