### PR TITLE
Added connection string provider

### DIFF
--- a/Serenity.Data/Connections/IConnectionStringProvider.cs
+++ b/Serenity.Data/Connections/IConnectionStringProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Configuration;
+
+namespace Serenity.Data
+{
+    interface IConnectionStringProvider
+    {
+        ConnectionStringSettings GetConnectionString(string connectionKey);
+    }
+}

--- a/Serenity.Data/Connections/SqlConnections.cs
+++ b/Serenity.Data/Connections/SqlConnections.cs
@@ -30,7 +30,9 @@ namespace Serenity.Data
             if (!connections.TryGetValue(connectionKey, out connection))
             {
                 var newConnections = new Dictionary<string, ConnectionStringInfo>(connections);
-                var connectionSetting = ConfigurationManager.ConnectionStrings[connectionKey];
+                var connectionStringProvider = Dependency.TryResolve<IConnectionStringProvider>();
+                var connectionSetting = connectionStringProvider?.GetConnectionString(connectionKey) ?? 
+                    ConfigurationManager.ConnectionStrings[connectionKey];
                 if (connectionSetting == null)
                     return null;
 

--- a/Serenity.Data/Serenity.Data.csproj
+++ b/Serenity.Data/Serenity.Data.csproj
@@ -52,6 +52,7 @@
     </Compile>
     <Compile Include="Connections\DataReaderExtensions.cs" />
     <Compile Include="Connections\IConnectionProfiler.cs" />
+    <Compile Include="Connections\IConnectionStringProvider.cs" />
     <Compile Include="Connections\IUnitOfWork.cs" />
     <Compile Include="Connections\ConnectionStringInfo.cs" />
     <Compile Include="Connections\UnitOfWork.cs" />


### PR DESCRIPTION
Hi.
Right now the only place to keep and provide connection strings is the default config file.
I wanted to make it a little bit more flexible. I'm not sure if you find that necessary, but I thought it could be useful in my projects.