### PR TITLE
Added NotAllowClear option for QuickFilter

### DIFF
--- a/Serenity.Script.UI/Editor/LookupEditor.cs
+++ b/Serenity.Script.UI/Editor/LookupEditor.cs
@@ -51,5 +51,9 @@ namespace Serenity
         /// In multiple mode, use a comma separated string, instead of an array when serializing value
         /// </summary>
         public bool Delimited { get; set; }
+        /// <summary>
+        /// If this property is true, the Select2Item is not clearable
+        /// </summary>
+        public bool NotAllowClear { get; set; }
     }
 }

--- a/Serenity.Script.UI/Editor/LookupEditor.cs
+++ b/Serenity.Script.UI/Editor/LookupEditor.cs
@@ -52,8 +52,8 @@ namespace Serenity
         /// </summary>
         public bool Delimited { get; set; }
         /// <summary>
-        /// If this property is true, the Select2Item is not clearable
+        /// If this property is false, the Select2Item is not clearable
         /// </summary>
-        public bool NotAllowClear { get; set; }
+        public bool AllowClear { get; set; }
     }
 }

--- a/Serenity.Script.UI/Editor/LookupEditor.cs
+++ b/Serenity.Script.UI/Editor/LookupEditor.cs
@@ -54,6 +54,6 @@ namespace Serenity
         /// <summary>
         /// If this property is false, the Select2Item is not clearable
         /// </summary>
-        public bool AllowClear { get; set; }
+        public bool? AllowClear { get; set; }
     }
 }

--- a/Serenity.Script.UI/Editor/LookupEditorBase.cs
+++ b/Serenity.Script.UI/Editor/LookupEditorBase.cs
@@ -289,8 +289,7 @@ namespace Serenity
             if (options.Multiple)
                 opt.Multiple = true;
             
-            if (options.NotAllowClear)
-                opt.AllowClear = false;
+            opt.AllowClear = options.AllowClear ?? true;
             
             return opt;
         }

--- a/Serenity.Script.UI/Editor/LookupEditorBase.cs
+++ b/Serenity.Script.UI/Editor/LookupEditorBase.cs
@@ -288,7 +288,10 @@ namespace Serenity
 
             if (options.Multiple)
                 opt.Multiple = true;
-
+            
+            if (options.NotAllowClear)
+                opt.AllowClear = false;
+            
             return opt;
         }
 


### PR DESCRIPTION
Hello @volkanceylan 

I have added an option for not display the clear button in lookup editor, in the quickfilteroption 

If set QuickFilterOption("NotAllowClear", "true") then the select2item is not clearable.

![notallowclear](https://cloud.githubusercontent.com/assets/16304015/19513692/22fef34e-95f1-11e6-9948-235df60a497b.PNG)

