### PR TITLE
Collapsible Categories

### DIFF
--- a/Serenity.Core/ComponentModel/PropertyGrid/CategoryAttribute.cs
+++ b/Serenity.Core/ComponentModel/PropertyGrid/CategoryAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Serenity.ComponentModel
+{
+    public class CategoryAttribute : Attribute
+    {
+        public CategoryAttribute(string category, bool collapsible = false, bool expanded = false)
+        {
+            Category = category;
+            Collapsible = collapsible;
+            Expanded = expanded;
+        }
+
+        public string Category { get; private set; }
+        public bool Collapsible { get; private set; }
+        public bool Expanded { get; private set; }
+    }
+}

--- a/Serenity.Core/ComponentModel/PropertyGrid/PropertyItem.cs
+++ b/Serenity.Core/ComponentModel/PropertyGrid/PropertyItem.cs
@@ -24,6 +24,10 @@ namespace Serenity.ComponentModel
         public Dictionary<string, object> EditorParams { get; set; }
         [JsonProperty("category")]
         public string Category { get; set; }
+        [JsonProperty("collapsible")]
+        public bool Collapsible { get; set; }
+        [JsonProperty("expanded")]
+        public bool Expanded { get; set; }
         [JsonProperty("cssClass")]
         public string CssClass { get; set; }
         [JsonProperty("maxLength")]
@@ -70,7 +74,7 @@ namespace Serenity.ComponentModel
         public bool? Sortable { get; set; }
         [JsonProperty("sortOrder")]
         public int? SortOrder { get; set; }
-       
+
         [JsonProperty("editLink")]
         public bool? EditLink { get; set; }
         [JsonProperty("editLinkItemType")]

--- a/Serenity.Data.Entity/PropertyGrid/BasicPropertyProcessor/BasicPropertyProcessor.Category.cs
+++ b/Serenity.Data.Entity/PropertyGrid/BasicPropertyProcessor/BasicPropertyProcessor.Category.cs
@@ -1,5 +1,4 @@
 ﻿using Serenity.ComponentModel;
-using System.ComponentModel;
 
 namespace Serenity.PropertyGrid
 {
@@ -8,8 +7,11 @@ namespace Serenity.PropertyGrid
         private void SetCategory(IPropertySource source, PropertyItem item)
         {
             var attr = source.GetAttribute<CategoryAttribute>();
-            if (attr != null)
+            if (attr != null) { 
                 item.Category = attr.Category;
+                item.Collapsible = attr.Collapsible;
+                item.Expanded = attr.Expanded;
+            }
             else if (Items != null && Items.Count > 0)
                 item.Category = Items[Items.Count - 1].Category;
         }

--- a/Serenity.Script.Imports/PropertyGrid/PropertyItem.cs
+++ b/Serenity.Script.Imports/PropertyGrid/PropertyItem.cs
@@ -14,6 +14,8 @@ namespace Serenity
         public string EditorType { get; set; }
         public JsDictionary EditorParams { get; set; }
         public string Category { get; set; }
+        public bool Collapsible { get; set; }
+        public bool Expanded { get; set; }
         public string CssClass { get; set; }
         public int? MaxLength { get; set; }
         public bool? Required { get; set; }

--- a/Serenity.Script.UI/PropertyGrid/Attributes/CategoryAttribute.cs
+++ b/Serenity.Script.UI/PropertyGrid/Attributes/CategoryAttribute.cs
@@ -5,13 +5,17 @@ namespace Serenity
 {
     public class CategoryAttribute : Attribute
     {
-        public CategoryAttribute(string category)
+        public CategoryAttribute(string category, bool collapsible = false, bool expanded = false)
         {
             Category = category;
+            Collapsible = collapsible;
+            Expanded = expanded;
         }
 
         [IntrinsicProperty]
         public string Category { get; private set; }
+        public bool Collapsible { get; private set; }
+        public bool Expanded { get; private set; }
     }
 }
 

--- a/Serenity.Script.UI/PropertyGrid/PropertyGrid.cs
+++ b/Serenity.Script.UI/PropertyGrid/PropertyGrid.cs
@@ -38,7 +38,7 @@ namespace Serenity
                     .AddClass("category-links");
 
                 categoryIndexes = CreateCategoryLinks(linkContainer, items);
-                
+
                 if (categoryIndexes.Count > 1)
                     linkContainer.AppendTo(div);
                 else
@@ -48,7 +48,7 @@ namespace Serenity
                     .AddClass("categories")
                     .AppendTo(div);
             }
-            
+
             var fieldContainer = categoriesDiv;
 
             string priorCategory = null;
@@ -59,7 +59,7 @@ namespace Serenity
                 if (options.UseCategories &&
                     priorCategory != item.Category)
                 {
-                    var categoryDiv = CreateCategoryDiv(categoriesDiv, categoryIndexes, item.Category);
+                    var categoryDiv = CreateCategoryDiv(categoriesDiv, categoryIndexes, item.Category, item.Collapsible, item.Expanded);
 
                     if (priorCategory == null)
                         categoryDiv.AddClass("first-category");
@@ -90,19 +90,63 @@ namespace Serenity
             base.Destroy();
         }
 
-        private jQueryObject CreateCategoryDiv(jQueryObject categoriesDiv, JsDictionary<string, int> categoryIndexes, string category)
+        private jQueryObject CreateCategoryDiv(jQueryObject categoriesDiv, JsDictionary<string, int> categoryIndexes, string category, bool collapsible, bool expanded)
         {
-            var categoryDiv = J("<div/>")
-                .AddClass("category")
-                .AppendTo(categoriesDiv);
+            var categoryId = options.IdPrefix + "Category" + categoryIndexes[category].ToString();
 
-            J("<div/>")
+            var categoryTitleDiv = J("<div/>")
                 .AddClass("category-title")
                 .Append(J("<a/>")
                     .AddClass("category-anchor")
                     .Text(DetermineText(category, prefix => prefix + "Categories." + category))
-                    .Attribute("name", options.IdPrefix + "Category" + categoryIndexes[category].ToString()))
-                .AppendTo(categoryDiv);
+                    .Attribute("name", categoryId));
+
+            var categoryDiv = J("<div/>")
+                .AddClass("category")
+                // add category-scroll class for CategoryLinkClick
+                .AddClass("category-scroll")
+                .Attribute("id", categoryId);
+
+            if (collapsible)
+            {
+                var button = J("<button class='btn btn-box-tool' data-target='#" + categoryId + "'></button>");
+                var i = J("<i class='fa'></i>");
+                categoryTitleDiv.Prepend(button.Append(i));
+                categoryTitleDiv.Attribute("href", "#" + categoryId);
+                categoryTitleDiv.Attribute("data-toggle", "collapse");
+                categoryDiv.AddClass("collapse");
+                if (expanded)
+                {
+                    categoryDiv.AddClass("in");
+                    i.AddClass("fa fa-minus");
+                }
+                else
+                {
+                    // remove category class in order to remove flex behaviour
+                    // that doesn't work properly with bootstrap collapse
+                    categoryDiv.RemoveClass("category");
+                    i.AddClass("fa fa-plus");
+                }
+
+                // bind to on collapse / expand events
+                categoryDiv.On("hide.bs.collapse", (e) =>
+                {
+                    i.RemoveClass("fa fa-minus");
+                    i.AddClass("fa fa-plus");
+                });
+                categoryDiv.On("hidden.bs.collapse", (e) =>
+                {
+                    categoryDiv.RemoveClass("category");
+                });
+                categoryDiv.On("show.bs.collapse", (e) =>
+                {
+                    categoryDiv.AddClass("category");
+                    i.RemoveClass("fa fa-plus");
+                    i.AddClass("fa fa-minus");
+                });
+            }
+            categoryTitleDiv.AppendTo(categoriesDiv);
+            categoryDiv.AppendTo(categoriesDiv);
 
             return categoryDiv;
         }
@@ -265,11 +309,11 @@ namespace Serenity
 
             var self = this;
             var categoryOrder = GetCategoryOrder(items);
-            
-            items.Sort((x, y) => 
+
+            items.Sort((x, y) =>
             {
                 var c = 0;
-                
+
                 if (x.Category != y.Category)
                 {
                     var c1 = categoryOrder[x.Category];
@@ -307,7 +351,7 @@ namespace Serenity
                             .AddClass("separator")
                             .Text("|")
                             .PrependTo(container);
-                    
+
                     J("<a/>")
                         .AddClass("category-link")
                         .Text(DetermineText(item.Category, prefix => prefix + "Categories." + item.Category))
@@ -331,15 +375,19 @@ namespace Serenity
 
             var title = J("a[name=" + e.Target.GetAttribute("href").ToString().Substr(1) + "]");
 
-            Action animate = delegate {
+            Action animate = delegate
+            {
                 title.FadeTo(100, 0.5, () => title.FadeTo(100, 1, () => { }));
             };
 
-            var intoView = title.Closest(".category");
+            var intoView = title.Parent().Next(".category-scroll");
+            if (!intoView.HasClass("in"))
+                ((dynamic)intoView).collapse("show");
             if (intoView.Closest(":scrollable(both)").Length == 0)
                 animate();
             else
-                ((dynamic)intoView).scrollintoview(new {
+                ((dynamic)intoView).scrollintoview(new
+                {
                     duration = "fast",
                     direction = "y",
                     complete = animate
@@ -351,8 +399,8 @@ namespace Serenity
             get { return this.editors.As<Widget[]>(); }
         }
 
-        public PropertyItem[] Items 
-        { 
+        public PropertyItem[] Items
+        {
             get { return this.items.As<PropertyItem[]>(); }
         }
 
@@ -428,14 +476,14 @@ namespace Serenity
                     (Mode == PropertyGridMode.Update && item.Updatable == false);
 
                 EditorUtils.SetReadOnly(editor, readOnly);
-                EditorUtils.SetRequired(editor, !readOnly && Q.IsTrue(item.Required) && 
+                EditorUtils.SetRequired(editor, !readOnly && Q.IsTrue(item.Required) &&
                     (item.EditorType != "Boolean"));
 
                 if (item.Visible == false ||
                     item.HideOnInsert == true ||
                     item.HideOnUpdate == true)
                 {
-                    bool hidden = 
+                    bool hidden =
                         item.Visible == false ||
                         (Mode == PropertyGridMode.Insert && item.HideOnInsert == true) ||
                         (Mode == PropertyGridMode.Update && item.HideOnUpdate == true);

--- a/Serenity.Script.UI/PropertyGrid/PropertyItemHelper.cs
+++ b/Serenity.Script.UI/PropertyGrid/PropertyItemHelper.cs
@@ -59,7 +59,11 @@ namespace Serenity
 
                 var categoryAttribute = member.GetCustomAttributes(typeof(CategoryAttribute), false);
                 if (categoryAttribute.Length == 1)
+                {
                     pi.Category = ((CategoryAttribute)categoryAttribute[0]).Category;
+                    pi.Collapsible = ((CategoryAttribute)categoryAttribute[0]).Collapsible;
+                    pi.Expanded = ((CategoryAttribute)categoryAttribute[0]).Expanded;
+                }
                 else if (categoryAttribute.Length > 1)
                     throw new Exception(String.Format("{0}.{1} için birden fazla kategori belirlenmiş!", type.Name, pi.Name));
                 else if (list.Count > 0)

--- a/Serenity.Web/Reporting/ReportRegistry.cs
+++ b/Serenity.Web/Reporting/ReportRegistry.cs
@@ -24,9 +24,9 @@ namespace Serenity.Reporting
 
         private static string GetReportCategory(Type type)
         {
-            var attr = type.GetCustomAttributes(typeof(CategoryAttribute), false);
+            var attr = type.GetCustomAttributes(typeof(ComponentModel.CategoryAttribute), false);
             if (attr.Length == 1)
-                return ((CategoryAttribute)attr[0]).Category;
+                return ((ComponentModel.CategoryAttribute)attr[0]).Category;
 
             return String.Empty;
         }
@@ -107,7 +107,7 @@ namespace Serenity.Reporting
             foreach (var k in reportsByCategory)
                 if (categoryKey.IsNullOrEmpty() ||
                     String.Compare(k.Key, categoryKey, StringComparison.OrdinalIgnoreCase) == 0 ||
-                    (k.Key + "/").StartsWith((categoryKey ?? ""), StringComparison.OrdinalIgnoreCase))
+                    (categoryKey ?? "").StartsWith(k.Key + "/", StringComparison.OrdinalIgnoreCase))
                 {
                     foreach (var report in k.Value)
                         if (report.Permission.IsNullOrEmpty() ||


### PR DESCRIPTION
Dear @volkanceylan,
I've implemented the possibility to collapse form categories.
Since this patch use the Serenity.ComponentModel.CategoryAttribute and a System.ComponentModel.CategoryAttribute class already exists , we need in every form (in Serene) to explicitly set the namespace or, if there aren't other System.ComponentModel attributes in such form, directly remove this:

    using System.ComponentModel;

Also the TranslationRepository.cs file need a fix (explicitly set the namespace).

This is how it looks like:

![image](https://cloud.githubusercontent.com/assets/17425690/20029016/5d2deb26-a341-11e6-807e-a8fac844454a.png)

Just a note: the flex behaviour it's not fully compatible with the bootstrap collapse functionality, so I had to use a dirty trick: remove the category css class when the category itself is collapsed and re-add such class when the category is expanded.

Hope it helps
Bye
