### PR TITLE
added TableName as const string at row.

### DIFF
--- a/Serenity.CodeGenerator/Views/EntityRowWithRegion.cshtml
+++ b/Serenity.CodeGenerator/Views/EntityRowWithRegion.cshtml
@@ -132,11 +132,12 @@ namespace @(Model.RootNamespace)@(dotModule).Entities
 
     #region RowFields
     public static readonly RowFields Fields = new RowFields().Init();
-
+    public const string TableName = String.IsNullOrEmpty(schemaDot) ? Model.Tablename : schemaDot + "[" + Model.Tablename + "]";
+    
     public partial class RowFields : @(Model.FieldsBaseClass)
     {
     public RowFields()
-    : base("@(String.IsNullOrEmpty(schemaDot) ? Model.Tablename : schemaDot + "[" + Model.Tablename + "]")"@(string.IsNullOrEmpty(Model.FieldPrefix) ? "" : (", \"" + Model.FieldPrefix + "\"")))
+    : base("@Model.RowClassName .TableName"@(string.IsNullOrEmpty(Model.FieldPrefix) ? "" : (", \"" + Model.FieldPrefix + "\"")))
     {
     LocalTextPrefix = "@(moduleDot)@(Model.ClassName)";
     }


### PR DESCRIPTION
the reason behind this is ability to write 
[ForeignKey(someRow.TableName, nameof(someRow.Id))]
instead of
[ForeignKey("TableName", "Id"))]