### PR TITLE
ForeignKeyAttribute: set "Id" as default primary field

### DIFF
--- a/Serenity.Data/Mapping/ForeignKeyAttribute.cs
+++ b/Serenity.Data/Mapping/ForeignKeyAttribute.cs
@@ -14,7 +14,7 @@ namespace Serenity.Data.Mapping
         /// </summary>
         /// <param name="table">Primary key table</param>
         /// <param name="field">Matching column in primary key table</param>
-        public ForeignKeyAttribute(string table, string field)
+        public ForeignKeyAttribute(string table, string field = "Id")
         {
             this.Field = field;
             this.Table = table;


### PR DESCRIPTION
This is my preference. I will be happy if you merge this.
I prefer Id as primary key for all tables. So `ForeignKey("TableName", "Id")` here "Id" is optional to me.
