### PR TITLE
AllowClear param in EnumEditor

### DIFF
--- a/Serenity.Core/ComponentModel/PropertyGrid/Editing/BasicEditorTypes.cs
+++ b/Serenity.Core/ComponentModel/PropertyGrid/Editing/BasicEditorTypes.cs
@@ -254,6 +254,20 @@ namespace Serenity.ComponentModel
         }
     }
 
+    public partial class EnumEditorAttribute : CustomEditorAttribute
+    {
+        public EnumEditorAttribute()
+            : base("Enum")
+        {
+        }
+
+        public Boolean AllowClear
+        {
+            get { return GetOption<Boolean>("allowClear"); }
+            set { SetOption("allowClear", value); }
+        }
+    }
+
     public abstract class LookupEditorBaseAttribute : CustomEditorAttribute
     {
         protected LookupEditorBaseAttribute(string editorType)

--- a/Serenity.Script.UI/Editor/EnumEditor.cs
+++ b/Serenity.Script.UI/Editor/EnumEditor.cs
@@ -36,6 +36,15 @@ namespace Serenity
                 AddItem(((int)x).ToString(), Q.TryGetText("Enums." + enumKey + "." + name) ?? name);
             }
         }
+
+        protected override Select2Options GetSelect2Options()
+        {
+            var opt = base.GetSelect2Options();
+
+            opt.AllowClear = options.AllowClear ?? true;
+
+            return opt;
+        }
     }
 
     [Serializable, Reflectable]
@@ -50,5 +59,8 @@ namespace Serenity
 
         [DisplayName("Enum Type Key"), Hidden]
         public Type EnumType { get; set; }
+
+        [DisplayName("Allow Clear"), EditorType("Boolean")]
+        public Boolean? AllowClear { get; set; }
     }
 }

--- a/Serenity.Test/Scripts/typings/serenity/Serenity.CoreLib.d.ts
+++ b/Serenity.Test/Scripts/typings/serenity/Serenity.CoreLib.d.ts
@@ -1193,6 +1193,7 @@ declare namespace Serenity {
     interface EnumEditorOptions {
         enumKey?: string;
         enumType?: any;
+        allowClear?: boolean;
     }
     interface HtmlContentEditorOptions {
         cols?: any;

--- a/Serenity.TypeScript.CoreLib/Serenity.CoreLib.d.ts
+++ b/Serenity.TypeScript.CoreLib/Serenity.CoreLib.d.ts
@@ -1193,6 +1193,7 @@ declare namespace Serenity {
     interface EnumEditorOptions {
         enumKey?: string;
         enumType?: any;
+        allowClear?: boolean;
     }
     interface HtmlContentEditorOptions {
         cols?: any;

--- a/Serenity.TypeScript.CoreLib/UI/Editors/Editors.ts
+++ b/Serenity.TypeScript.CoreLib/UI/Editors/Editors.ts
@@ -48,6 +48,7 @@
     interface EnumEditorOptions {
         enumKey?: string;
         enumType?: any;
+        allowClear?: boolean;
     }
 
     interface HtmlContentEditorOptions {


### PR DESCRIPTION
@volkanceylan I have added the AllowClear parameter (as default true) to make possible set it to false and render enum list not clearable.

