### PR TITLE
Full Text Search

### DIFF
--- a/Serenity.Core/ComponentModel/Columns/Filtering/FullTextIndexAttribute.cs
+++ b/Serenity.Core/ComponentModel/Columns/Filtering/FullTextIndexAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Serenity.ComponentModel
+{
+    public class FullTextIndexAttribute : Attribute
+    {
+        public FullTextIndexAttribute(bool value = true)
+        {
+            this.Value = value;
+        }
+
+        public bool Value
+        {
+            get;
+            private set;
+        }
+    }
+}

--- a/Serenity.Core/ComponentModel/PropertyGrid/PropertyItem.cs
+++ b/Serenity.Core/ComponentModel/PropertyGrid/PropertyItem.cs
@@ -97,6 +97,8 @@ namespace Serenity.ComponentModel
         public bool? FilterOnly { get; set; }
         [JsonProperty("notFilterable")]
         public bool? NotFilterable { get; set; }
+        [JsonProperty("fullTextIndex")]
+        public bool? FullTextIndex { get; set; }
 
         [JsonProperty("quickFilter")]
         public bool? QuickFilter { get; set; }

--- a/Serenity.Core/Serenity.Core.Net45.csproj
+++ b/Serenity.Core/Serenity.Core.Net45.csproj
@@ -64,6 +64,7 @@
     <Compile Include="ComponentModel\Columns\Filtering\BasicFilteringTypes\EnumFilteringAttribute.cs" />
     <Compile Include="ComponentModel\Columns\Filtering\FilteringIdFieldAttribute.cs" />
     <Compile Include="ComponentModel\Columns\Filtering\QuickFilterOptionAttribute.cs" />
+    <Compile Include="ComponentModel\Columns\Filtering\FullTextIndexAttribute.cs" />
     <Compile Include="ComponentModel\Columns\Filtering\SortableAttribute.cs" />
     <Compile Include="ComponentModel\Columns\Filtering\QuickFilterAttribute.cs" />
     <Compile Include="ComponentModel\Columns\Filtering\NotFilterableAttribute.cs" />

--- a/Serenity.Data.Entity/PropertyGrid/BasicPropertyProcessor/BasicPropertyProcessor.Filtering.cs
+++ b/Serenity.Data.Entity/PropertyGrid/BasicPropertyProcessor/BasicPropertyProcessor.Filtering.cs
@@ -12,12 +12,16 @@ namespace Serenity.PropertyGrid
         {
             var filterOnlyAttr = source.GetAttribute<FilterOnlyAttribute>();
             var notFilterableAttr = source.GetAttribute<NotFilterableAttribute>();
+            var fullTextIndexAttr = source.GetAttribute<FullTextIndexAttribute>();
 
             if (filterOnlyAttr != null && filterOnlyAttr.Value)
                 item.FilterOnly = true;
 
             if (notFilterableAttr != null && notFilterableAttr.Value)
                 item.NotFilterable = true;
+
+            if (fullTextIndexAttr != null && fullTextIndexAttr.Value)
+                item.FullTextIndex = true;
 
             if (item.NotFilterable == true)
                 return;

--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -44,11 +44,6 @@
             return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria(mask));
         }
 
-        public BaseCriteria FullTextSearchFreeText(string mask)
-        {
-            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchFreetext, new ValueCriteria(mask));
-        }
-
         public BaseCriteria FullTextSearchStartsWith(string mask)
         {
             if (mask == null)

--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -18,7 +18,7 @@
         {
             get { return false; }
         }
-        
+
         public BaseCriteria IsNull()
         {
             return new UnaryCriteria(CriteriaOperator.IsNull, this);
@@ -37,6 +37,24 @@
         public BaseCriteria NotLike(string mask)
         {
             return new BinaryCriteria(this, CriteriaOperator.NotLike, new ValueCriteria(mask));
+        }
+
+        public BaseCriteria FullTextSearchContains(string mask)
+        {
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria(mask));
+        }
+
+        public BaseCriteria FullTextSearchFreeText(string mask)
+        {
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchFreetext, new ValueCriteria(mask));
+        }
+
+        public BaseCriteria FullTextSearchStartsWith(string mask)
+        {
+            if (mask == null)
+                throw new ArgumentNullException("mask");
+
+            return FullTextSearchContains("\"" + mask + "*\"");
         }
 
         public BaseCriteria StartsWith(string mask)
@@ -97,7 +115,7 @@
             if (Object.ReferenceEquals(null, statement) || statement.IsEmpty)
                 throw new ArgumentNullException("statement");
 
-            return new BinaryCriteria(this, CriteriaOperator.In, statement); 
+            return new BinaryCriteria(this, CriteriaOperator.In, statement);
         }
 
         public BaseCriteria InStatement(BaseCriteria statement)
@@ -471,7 +489,7 @@
 
             return new BinaryCriteria(criteria1, op, criteria2);
         }
-        
+
         public static BaseCriteria operator &(BaseCriteria criteria1, BaseCriteria criteria2)
         {
             return JoinIf(criteria1, criteria2, CriteriaOperator.AND);

--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -41,12 +41,12 @@
 
         public BaseCriteria FullTextSearchContains(string mask)
         {
-            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask + "\""));
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask.Replace("\"", "\"\"") + "\""));
         }
 
         public BaseCriteria FullTextSearchStartsWith(string mask)
         {
-            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask + "*\""));
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask.Replace("\"", "\"\"") + "*\""));
         }
 
         public BaseCriteria StartsWith(string mask)

--- a/Serenity.Data/Criteria/BaseCriteria.cs
+++ b/Serenity.Data/Criteria/BaseCriteria.cs
@@ -41,15 +41,12 @@
 
         public BaseCriteria FullTextSearchContains(string mask)
         {
-            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria(mask));
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask + "\""));
         }
 
         public BaseCriteria FullTextSearchStartsWith(string mask)
         {
-            if (mask == null)
-                throw new ArgumentNullException("mask");
-
-            return FullTextSearchContains("\"" + mask + "*\"");
+            return new BinaryCriteria(this, CriteriaOperator.FullTextSearchContains, new ValueCriteria("\"" + mask + "*\""));
         }
 
         public BaseCriteria StartsWith(string mask)

--- a/Serenity.Data/Criteria/BinaryCriteria.cs
+++ b/Serenity.Data/Criteria/BinaryCriteria.cs
@@ -17,6 +17,7 @@
             if (ReferenceEquals(right, null))
                 throw new ArgumentNullException("right");
 
+            if (op < CriteriaOperator.AND || op > CriteriaOperator.FullTextSearchStartWith)
                 throw new ArgumentOutOfRangeException("op");
 
             this.left = left;

--- a/Serenity.Data/Criteria/BinaryCriteria.cs
+++ b/Serenity.Data/Criteria/BinaryCriteria.cs
@@ -17,7 +17,7 @@
             if (ReferenceEquals(right, null))
                 throw new ArgumentNullException("right");
 
-            if (op < CriteriaOperator.AND || op > CriteriaOperator.NotLike)
+            if (op < CriteriaOperator.AND || op > CriteriaOperator.FullTextSearchFreetext)
                 throw new ArgumentOutOfRangeException("op");
 
             this.left = left;
@@ -47,6 +47,24 @@
                     sb.Append(this.op == CriteriaOperator.Like ? " LIKE " : " NOT LIKE ");
                     this.right.ToString(sb, query);
                 }
+            }
+            else if (this.op == CriteriaOperator.FullTextSearchContains)
+            {
+                // Full-text search queries are case-insensitive
+                sb.Append("CONTAINS(");
+                this.left.ToString(sb, query);
+                sb.Append(',');
+                this.right.ToString(sb, query);
+                sb.Append(")");
+            }
+            else if (this.op == CriteriaOperator.FullTextSearchFreetext)
+            {
+                // Full-text search queries are case-insensitive
+                sb.Append("FREETEXT(");
+                this.left.ToString(sb, query);
+                sb.Append(',');
+                this.right.ToString(sb, query);
+                sb.Append(")");
             }
             else
             {

--- a/Serenity.Data/Criteria/BinaryCriteria.cs
+++ b/Serenity.Data/Criteria/BinaryCriteria.cs
@@ -48,7 +48,7 @@
                     this.right.ToString(sb, query);
                 }
             }
-            else if (this.op == CriteriaOperator.FullTextSearchContains)
+            else if (this.op == CriteriaOperator.FullTextSearchContains || this.op == CriteriaOperator.FullTextSearchStartWith)
             {
                 // Full-text search queries are case-insensitive
                 sb.Append("CONTAINS(");

--- a/Serenity.Data/Criteria/BinaryCriteria.cs
+++ b/Serenity.Data/Criteria/BinaryCriteria.cs
@@ -17,7 +17,6 @@
             if (ReferenceEquals(right, null))
                 throw new ArgumentNullException("right");
 
-            if (op < CriteriaOperator.AND || op > CriteriaOperator.FullTextSearchFreetext)
                 throw new ArgumentOutOfRangeException("op");
 
             this.left = left;
@@ -52,15 +51,6 @@
             {
                 // Full-text search queries are case-insensitive
                 sb.Append("CONTAINS(");
-                this.left.ToString(sb, query);
-                sb.Append(',');
-                this.right.ToString(sb, query);
-                sb.Append(")");
-            }
-            else if (this.op == CriteriaOperator.FullTextSearchFreetext)
-            {
-                // Full-text search queries are case-insensitive
-                sb.Append("FREETEXT(");
                 this.left.ToString(sb, query);
                 sb.Append(',');
                 this.right.ToString(sb, query);

--- a/Serenity.Data/Criteria/CriteriaOperator.cs
+++ b/Serenity.Data/Criteria/CriteriaOperator.cs
@@ -21,6 +21,6 @@
         Like,
         NotLike,
         FullTextSearchContains,
-        FullTextSearchFreetext
+        FullTextSearchStartWith
     }
 }

--- a/Serenity.Data/Criteria/CriteriaOperator.cs
+++ b/Serenity.Data/Criteria/CriteriaOperator.cs
@@ -20,5 +20,7 @@
         NotIn,
         Like,
         NotLike,
+        FullTextSearchContains,
+        FullTextSearchFreetext
     }
 }

--- a/Serenity.Data/Criteria/JsonCriteriaConverter.cs
+++ b/Serenity.Data/Criteria/JsonCriteriaConverter.cs
@@ -269,7 +269,8 @@ namespace Serenity.Data
             "not in", // NOT IN
             "like", // LIKE
             "not like", // NOT LIKE
-            "contains" // FULL TEXT SEARCH - CONTAINS
+            "contains", // FULL TEXT SEARCH - CONTAINS
+            "starts with" // FULL TEXT SEARCH - STARTS WITH
         };
 
         private static readonly Dictionary<string, CriteriaOperator> KeyToOperator;

--- a/Serenity.Data/Criteria/JsonCriteriaConverter.cs
+++ b/Serenity.Data/Criteria/JsonCriteriaConverter.cs
@@ -270,7 +270,7 @@ namespace Serenity.Data
             "like", // LIKE
             "not like", // NOT LIKE
             "contains", // FULL TEXT SEARCH - CONTAINS
-            "starts with" // FULL TEXT SEARCH - STARTS WITH
+            "startswith" // FULL TEXT SEARCH - STARTS WITH
         };
 
         private static readonly Dictionary<string, CriteriaOperator> KeyToOperator;

--- a/Serenity.Data/Criteria/JsonCriteriaConverter.cs
+++ b/Serenity.Data/Criteria/JsonCriteriaConverter.cs
@@ -211,7 +211,7 @@ namespace Serenity.Data
                 if (!KeyToOperator.TryGetValue(opStr, out op))
                     throw new JsonSerializationException(String.Format("Unknown Criteria operator: {0}", opStr));
 
-                if (op < CriteriaOperator.AND || op > CriteriaOperator.NotLike)
+                if (op < CriteriaOperator.AND || op > CriteriaOperator.FullTextSearchStartWith)
                     throw new JsonSerializationException(String.Format("Invalid Criteria format: {0}", array.ToString()));
 
                 return new BinaryCriteria(ParseValue(array[0]), op, ParseValue(array[2]));
@@ -268,7 +268,8 @@ namespace Serenity.Data
             "in", // IN
             "not in", // NOT IN
             "like", // LIKE
-            "not like" // NOT LIKE
+            "not like", // NOT LIKE
+            "contains" // FULL TEXT SEARCH - CONTAINS
         };
 
         private static readonly Dictionary<string, CriteriaOperator> KeyToOperator;

--- a/Serenity.Data/Mapping/SearchType.cs
+++ b/Serenity.Data/Mapping/SearchType.cs
@@ -6,9 +6,6 @@ namespace Serenity.Data.Mapping
         Auto = 0,
         Equals = 1,
         Contains = 2,
-        StartsWith = 3,
-        FullTextSearchContains = 4,
-        FullTextSearchStartsWith = 5,
-        FullTextSearchFreeText = 6
+        StartsWith = 3
     }
 }

--- a/Serenity.Data/Mapping/SearchType.cs
+++ b/Serenity.Data/Mapping/SearchType.cs
@@ -6,6 +6,9 @@ namespace Serenity.Data.Mapping
         Auto = 0,
         Equals = 1,
         Contains = 2,
-        StartsWith = 3
+        StartsWith = 3,
+        FullTextSearchContains = 4,
+        FullTextSearchStartsWith = 5,
+        FullTextSearchFreeText = 6
     }
 }

--- a/Serenity.Script.Imports/Criteria/BaseCriteria.cs
+++ b/Serenity.Script.Imports/Criteria/BaseCriteria.cs
@@ -65,7 +65,7 @@
             return null;
         }
 
-        [InlineCode("[{this}, 'starts with', {mask}]")]
+        [InlineCode("[{this}, 'startswith', ('\"' + {mask} + '*\"')]")]
         public BaseCriteria FullTextSearchStartsWith(string mask)
         {
             return null;

--- a/Serenity.Script.Imports/Criteria/BaseCriteria.cs
+++ b/Serenity.Script.Imports/Criteria/BaseCriteria.cs
@@ -59,6 +59,12 @@
             return null;
         }
 
+        [InlineCode("[{this}, 'contains', {mask}]")]
+        public BaseCriteria FullTextSearchContains(string mask)
+        {
+            return null;
+        }
+
         [InlineCode("[{this}, 'not like', ('%' + {mask} + '%')]")]
         public BaseCriteria NotContains(string mask)
         {
@@ -334,7 +340,7 @@
         {
             return null;
         }
-        
+
         [InlineCode("[{criteria1}, '<=', {criteria2}]")]
         public static BaseCriteria operator <=(BaseCriteria criteria1, BaseCriteria criteria2)
         {
@@ -382,7 +388,7 @@
         {
             return null;
         }
-       
+
         [InlineCode("Serenity.Criteria.join({criteria1}, 'and', {criteria2})")]
         public static BaseCriteria operator &(BaseCriteria criteria1, BaseCriteria criteria2)
         {

--- a/Serenity.Script.Imports/Criteria/BaseCriteria.cs
+++ b/Serenity.Script.Imports/Criteria/BaseCriteria.cs
@@ -59,13 +59,13 @@
             return null;
         }
 
-        [InlineCode("[{this}, 'contains', ('\"' + {mask} + '\"')]")]
+        [InlineCode("[{this}, 'contains', ('\"' + Q.replaceAll({mask},'\"','\"\"') + '\"')]")]
         public BaseCriteria FullTextSearchContains(string mask)
         {
             return null;
         }
 
-        [InlineCode("[{this}, 'startswith', ('\"' + {mask} + '*\"')]")]
+        [InlineCode("[{this}, 'startswith', ('\"' + Q.replaceAll({mask},'\"','\"\"') + '*\"')]")]
         public BaseCriteria FullTextSearchStartsWith(string mask)
         {
             return null;

--- a/Serenity.Script.Imports/Criteria/BaseCriteria.cs
+++ b/Serenity.Script.Imports/Criteria/BaseCriteria.cs
@@ -59,7 +59,7 @@
             return null;
         }
 
-        [InlineCode("[{this}, 'contains', {mask}]")]
+        [InlineCode("[{this}, 'contains', ('\"' + {mask} + '\"')]")]
         public BaseCriteria FullTextSearchContains(string mask)
         {
             return null;

--- a/Serenity.Script.Imports/Criteria/BaseCriteria.cs
+++ b/Serenity.Script.Imports/Criteria/BaseCriteria.cs
@@ -65,6 +65,12 @@
             return null;
         }
 
+        [InlineCode("[{this}, 'starts with', {mask}]")]
+        public BaseCriteria FullTextSearchStartsWith(string mask)
+        {
+            return null;
+        }
+
         [InlineCode("[{this}, 'not like', ('%' + {mask} + '%')]")]
         public BaseCriteria NotContains(string mask)
         {

--- a/Serenity.Script.Imports/PropertyGrid/PropertyItem.cs
+++ b/Serenity.Script.Imports/PropertyGrid/PropertyItem.cs
@@ -54,6 +54,7 @@ namespace Serenity
         public string FilteringIdField { get; set; }
         public bool? NotFilterable { get; set; }
         public bool? FilterOnly { get; set; }
+        public bool? FullTextIndex { get; set; }
 
         public bool? QuickFilter { get; set; }
         public JsDictionary QuickFilterParams { get; set; }

--- a/Serenity.Script.UI/FilterPanel/FilteringTypes/BaseFiltering.cs
+++ b/Serenity.Script.UI/FilterPanel/FilteringTypes/BaseFiltering.cs
@@ -127,7 +127,14 @@ namespace Serenity
                 case FilterOperators.StartsWith:
                     text = GetEditorText();
                     displayText = DisplayText(Operator, text);
-                    return new Criteria(GetCriteriaField()).StartsWith(text);
+                    if (Field.FullTextIndex ?? false)
+                    {
+                        return new Criteria(GetCriteriaField()).FullTextSearchStartsWith(text);
+                    }
+                    else
+                    {
+                        return new Criteria(GetCriteriaField()).StartsWith(text);
+                    }
 
                 case FilterOperators.EQ:
                 case FilterOperators.NE:

--- a/Serenity.Script.UI/FilterPanel/FilteringTypes/BaseFiltering.cs
+++ b/Serenity.Script.UI/FilterPanel/FilteringTypes/BaseFiltering.cs
@@ -115,7 +115,14 @@ namespace Serenity
                 case FilterOperators.Contains:
                     text = GetEditorText();
                     displayText = DisplayText(Operator, text);
-                    return new Criteria(GetCriteriaField()).Contains(text);
+                    if (Field.FullTextIndex ?? false)
+                    {
+                        return new Criteria(GetCriteriaField()).FullTextSearchContains(text);
+                    }
+                    else
+                    {
+                        return new Criteria(GetCriteriaField()).Contains(text);
+                    }
 
                 case FilterOperators.StartsWith:
                     text = GetEditorText();
@@ -130,7 +137,7 @@ namespace Serenity
                 case FilterOperators.GE:
                     text = GetEditorText();
                     displayText = DisplayText(Operator, text);
-                    return new BinaryCriteria(new Criteria(GetCriteriaField()), FilterOperators.ToCriteriaOperator[Operator.Key], 
+                    return new BinaryCriteria(new Criteria(GetCriteriaField()), FilterOperators.ToCriteriaOperator[Operator.Key],
                         new ValueCriteria(GetEditorValue()));
             }
 

--- a/Serenity.Script.UI/PropertyGrid/Attributes/FullTextIndexAttribute.cs
+++ b/Serenity.Script.UI/PropertyGrid/Attributes/FullTextIndexAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Serenity
+{
+    public class FullTextIndexAttribute : Attribute
+    {
+        public FullTextIndexAttribute() : this(true)
+        {
+        }
+
+        public FullTextIndexAttribute(bool value)
+        {
+            this.Value = value;
+        }
+
+        [IntrinsicProperty]
+        public bool Value { get; private set; }
+    }
+}

--- a/Serenity.Script.UI/PropertyGrid/PropertyItemHelper.cs
+++ b/Serenity.Script.UI/PropertyGrid/PropertyItemHelper.cs
@@ -138,6 +138,10 @@ namespace Serenity
                 if (reqAttr.Length > 0)
                     pi.Required = reqAttr[0].As<RequiredAttribute>().IsRequired;
 
+                var fullTextIndexAttr = member.GetCustomAttributes(typeof(FullTextIndexAttribute), true);
+                if (fullTextIndexAttr.Length > 0)
+                    pi.FullTextIndex = fullTextIndexAttr[0].As<FullTextIndexAttribute>().Value;
+
                 var maxLengthAttr = member.GetCustomAttributes(typeof(MaxLengthAttribute), false);
                 if (maxLengthAttr.Length > 0)
                 {

--- a/Serenity.Script.UI/Serenity.Script.UI.csproj
+++ b/Serenity.Script.UI/Serenity.Script.UI.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Editor\URLEditor.cs" />
     <Compile Include="Editor\MaskEditor.cs" />
     <Compile Include="Editor\PhoneEditor.cs" />
+    <Compile Include="PropertyGrid\Attributes\FullTextIndexAttribute.cs" />
     <Compile Include="FilterPanel\FilteringTypes\BaseEditorFiltering.cs" />
     <Compile Include="FilterPanel\FilteringTypes\EnumFiltering.cs" />
     <Compile Include="FilterPanel\FilteringTypes\DateTimeFiltering.cs" />

--- a/Serenity.Services/RequestHandlers/List/ListRequestHandler.cs
+++ b/Serenity.Services/RequestHandlers/List/ListRequestHandler.cs
@@ -12,9 +12,9 @@
     using System.Reflection;
 
     public class ListRequestHandler<TRow, TListRequest, TListResponse> : IListRequestHandler, IListRequestProcessor
-        where TRow: Row, new()
-        where TListRequest: ListRequest
-        where TListResponse: ListResponse<TRow>, new()
+        where TRow : Row, new()
+        where TListRequest : ListRequest
+        where TListResponse : ListResponse<TRow>, new()
     {
         protected TRow Row;
         protected TListRequest Request;
@@ -69,7 +69,7 @@
         protected virtual bool ShouldSelectField(Field field)
         {
             var mode = field.MinSelectLevel;
-            
+
             if (mode == SelectLevel.Always)
                 return true;
 
@@ -143,7 +143,7 @@
                     SelectField(query, field);
             }
         }
-    
+
         protected virtual void PrepareQuery(SqlQuery query)
         {
             SelectFields(query);
@@ -185,8 +185,8 @@
 
             var field = Row.FindField(containsField) ?? Row.FindFieldByPropertyName(containsField);
             if (ReferenceEquals(null, field) ||
-                ((field.MinSelectLevel == SelectLevel.Never) && 
-                    (field.CustomAttributes == null || 
+                ((field.MinSelectLevel == SelectLevel.Never) &&
+                    (field.CustomAttributes == null ||
                      !field.CustomAttributes.OfType<QuickSearchAttribute>().Any())))
             {
                 throw new ArgumentOutOfRangeException("containsField");
@@ -195,7 +195,7 @@
             return new Field[] { field };
         }
 
-        protected virtual void AddFieldContainsCriteria(Field field, string containsText, long? id, 
+        protected virtual void AddFieldContainsCriteria(Field field, string containsText, long? id,
             SearchType searchType, bool numericOnly, ref BaseCriteria criteria, ref bool orFalse)
         {
             if (numericOnly == true && (id == null))
@@ -208,6 +208,18 @@
             {
                 case SearchType.Contains:
                     criteria |= new Criteria(field).Contains(containsText);
+                    break;
+
+                case SearchType.FullTextSearchContains:
+                    criteria |= new Criteria(field).FullTextSearchContains(containsText);
+                    break;
+
+                case SearchType.FullTextSearchStartsWith:
+                    criteria |= new Criteria(field).FullTextSearchStartsWith(containsText);
+                    break;
+
+                case SearchType.FullTextSearchFreeText:
+                    criteria |= new Criteria(field).FullTextSearchFreeText(containsText);
                     break;
 
                 case SearchType.StartsWith:
@@ -365,7 +377,7 @@
                 field.Flags.HasFlag(FieldFlags.DenyFiltering) ||
                 field.Flags.HasFlag(FieldFlags.NotMapped))
             {
-                throw new ArgumentOutOfRangeException(field.PropertyName ?? field.Name, 
+                throw new ArgumentOutOfRangeException(field.PropertyName ?? field.Name,
                     String.Format("Can't apply equality filter on field {0}", field.PropertyName ?? field.Name));
             }
 
@@ -394,7 +406,7 @@
             if (value is string && ((string)value).Length == 0)
                 return true;
 
-            if (!(value is string) && value is IEnumerable && 
+            if (!(value is string) && value is IEnumerable &&
                 !((value as IEnumerable).GetEnumerator().MoveNext()))
                 return true;
 
@@ -417,7 +429,7 @@
 
                 var field = Row.FindFieldByPropertyName(pair.Key) ?? Row.FindField(pair.Key);
                 if (ReferenceEquals(null, field))
-                    throw new ArgumentOutOfRangeException(pair.Key, 
+                    throw new ArgumentOutOfRangeException(pair.Key,
                         String.Format("Can't find field {0} in row for equality filter.", pair.Key));
 
                 ApplyFieldEqualityFilter(query, field, pair.Value);
@@ -522,7 +534,7 @@
 
             OnBeforeExecuteQuery();
 
-            Response.TotalCount = query.ForEach(Connection, delegate()
+            Response.TotalCount = query.ForEach(Connection, delegate ()
             {
                 var clone = ProcessEntity(Row.Clone());
 
@@ -569,7 +581,7 @@
 
     public class ListRequestHandler<TRow, TListRequest> : ListRequestHandler<TRow, TListRequest, ListResponse<TRow>>
         where TRow : Row, new()
-        where TListRequest: ListRequest
+        where TListRequest : ListRequest
     {
     }
 

--- a/Serenity.Services/RequestHandlers/List/ListRequestHandler.cs
+++ b/Serenity.Services/RequestHandlers/List/ListRequestHandler.cs
@@ -204,26 +204,30 @@
                 return;
             }
 
+            var fullTextIndex = field.GetAttribute<FullTextIndexAttribute>();
+            var hasFullTextIndex = fullTextIndex != null && fullTextIndex.Value;
             switch (searchType)
             {
                 case SearchType.Contains:
-                    criteria |= new Criteria(field).Contains(containsText);
-                    break;
-
-                case SearchType.FullTextSearchContains:
-                    criteria |= new Criteria(field).FullTextSearchContains(containsText);
-                    break;
-
-                case SearchType.FullTextSearchStartsWith:
-                    criteria |= new Criteria(field).FullTextSearchStartsWith(containsText);
-                    break;
-
-                case SearchType.FullTextSearchFreeText:
-                    criteria |= new Criteria(field).FullTextSearchFreeText(containsText);
+                    if (hasFullTextIndex)
+                    {
+                        criteria |= new Criteria(field).FullTextSearchContains(containsText);
+                    }
+                    else
+                    {
+                        criteria |= new Criteria(field).Contains(containsText);
+                    }
                     break;
 
                 case SearchType.StartsWith:
-                    criteria |= new Criteria(field).StartsWith(containsText);
+                    if (hasFullTextIndex)
+                    {
+                        criteria |= new Criteria(field).FullTextSearchStartsWith(containsText);
+                    }
+                    else
+                    {
+                        criteria |= new Criteria(field).StartsWith(containsText);
+                    }
                     break;
 
                 case SearchType.Equals:


### PR DESCRIPTION
Dear @volkanceylan,
this is a basic support of sql server full text search.
It should work properly on quicksearch, criteria and advanced filters: in order to do that I've added also a new attribute "FullTextIndex".

Edit: just a note...I've added the "CONTAINS" support both with simple_term and prefix_term. The first one it's a replacement of "LIKE" if the field has the FullTextIndex attribute and the behaviour it's the same (only more faster!). About the the prefix_term instead, there is a little (but important) difference: the "startswith" match all words (or phrases) that begins with such term, while the "like" implementation only look at the very beginning of the field.

Let me know if it's ok!
Thanks
Bye