### PR TITLE
Skip Take With Order By clause used correct syntax for OracleDialect

### DIFF
--- a/Serenity.Data/FluentSql/SqlQuery_ToString.cs
+++ b/Serenity.Data/FluentSql/SqlQuery_ToString.cs
@@ -254,7 +254,23 @@ namespace Serenity.Data
 
                 if (useRowNum)
                 {
-                    sb.Append("ROWNUM AS numberingofrow");
+                    if (orderBy != null)
+                    {
+                        sb.Append("ROW_NUMBER() OVER (ORDER BY ");
+                        for (int i = 0; i < orderBy.Count; i++)
+                        {
+                            if (i > 0)
+                                sb.Append(", ");
+
+                            sb.Append(orderBy[i]);
+                        }
+
+                        sb.Append(") AS numberingofrow");
+                    }
+                    else
+                    {
+                        sb.Append("ROWNUM AS numberingofrow");
+                    }
                 }
                 else
                 {
@@ -271,7 +287,7 @@ namespace Serenity.Data
 
                     sb.Append(") AS __num__");
                 }
-                
+
             }
 
             // select sorgusunun kalan kısımlarını yaz
@@ -339,7 +355,7 @@ namespace Serenity.Data
 
                 AppendFromWhereOrderByGroupByHaving(sb, null, false);
 
-                if (distinct || (groupBy!= null && groupBy.Length > 0))
+                if (distinct || (groupBy != null && groupBy.Length > 0))
                 {
                     sb.Append(") _alias_");
                 }

--- a/Serenity.Test/Sql/SqlQueryTests.cs
+++ b/Serenity.Test/Sql/SqlQueryTests.cs
@@ -561,18 +561,18 @@ namespace Serenity.Test.Data
                 .Where("c > 2")
                 .OrderBy("x")
                 .OrderBy("y")
-                
+
                 .Skip(100)
                 .Take(50);
 
             Assert.Equal(
                 TestSqlHelper.Normalize(
-                    "DECLARE @Value0 SQL_VARIANT;" + 
+                    "DECLARE @Value0 SQL_VARIANT;" +
                     "DECLARE @Value1 SQL_VARIANT;" +
                     "SELECT TOP 100 @Value0 = x,@Value1 = y FROM t WHERE c > 2 ORDER BY x, y;" +
-                    "SELECT TOP 50 c FROM t WHERE c > 2 AND " + 
-                        "((((x IS NOT NULL AND @Value0 IS NULL) OR (x > @Value0))) " + 
-                            "OR (((x IS NULL AND @Value0 IS NULL) OR (x = @Value0)) " + 
+                    "SELECT TOP 50 c FROM t WHERE c > 2 AND " +
+                        "((((x IS NOT NULL AND @Value0 IS NULL) OR (x > @Value0))) " +
+                            "OR (((x IS NULL AND @Value0 IS NULL) OR (x = @Value0)) " +
                             "AND ((y IS NOT NULL AND @Value1 IS NULL) OR (y > @Value1)))) ORDER BY x, y"),
                 TestSqlHelper.Normalize(
                     query.ToString()));
@@ -592,7 +592,7 @@ namespace Serenity.Test.Data
             Assert.Equal(
                 TestSqlHelper.Normalize(
                     "SELECT * FROM (\n" +
-                        "SELECT TOP 30 c, ROW_NUMBER() OVER (ORDER BY x) AS __num__ FROM t) __results__ " + 
+                        "SELECT TOP 30 c, ROW_NUMBER() OVER (ORDER BY x) AS __num__ FROM t) __results__ " +
                     "WHERE __num__ > 10"),
                 TestSqlHelper.Normalize(
                     query.ToString()));
@@ -711,7 +711,7 @@ namespace Serenity.Test.Data
             Assert.Throws<ArgumentNullException>(() => new SqlQuery().Where((string)null));
             Assert.Throws<ArgumentNullException>(() => new SqlQuery().Where(String.Empty));
         }
-        
+
         [Fact]
         public void WithPassesAndReturnsTheQueryItself()
         {
@@ -793,6 +793,24 @@ namespace Serenity.Test.Data
             Assert.Equal(
                 TestSqlHelper.Normalize(
                     "SELECT * FROM ( SELECT c, ROWNUM AS numberingofrow FROM t) WHERE numberingofrow > 50 AND ROWNUM <= 20"),
+                TestSqlHelper.Normalize(
+                    query.ToString()));
+        }
+
+        [Fact]
+        public void SkipTakeWithOrderByUsesCorrectSyntaxForOracleDialect()
+        {
+            var query = new SqlQuery()
+                .Dialect(OracleDialect.Instance)
+                .Select("c")
+                .From("t")
+                .OrderBy("x")
+                .Take(20)
+                .Skip(50);
+
+            Assert.Equal(
+                TestSqlHelper.Normalize(
+                    "SELECT * FROM ( SELECT c, ROW_NUMBER() OVER (ORDER BY x) AS numberingofrow FROM t ORDER BY x) WHERE numberingofrow > 50 AND ROWNUM <= 20"),
                 TestSqlHelper.Normalize(
                     query.ToString()));
         }


### PR DESCRIPTION
Before this,
Pagination in grid was wrongly behaved when using Order By clause in OracleDialect