### PR TITLE
validateOptions .ignore behaviour change

### DIFF
--- a/Serenity.TypeScript.CoreLib/Externals/Serenity.Externals.ts
+++ b/Serenity.TypeScript.CoreLib/Externals/Serenity.Externals.ts
@@ -185,7 +185,7 @@ namespace Q {
 
     export function validateOptions(options: JQueryValidation.ValidationOptions) {
         return $.extend({
-            ignore: ":hidden",
+            ignore: Q.isEmptyOrNull(options.ignore) ? ":hidden" : options.ignore,
             meta: 'v',
             errorClass: 'error',
             errorPlacement: function (error: any, element: any) {


### PR DESCRIPTION
Dear Volkan,
this is related to my previous issue concerning the default value of the .ignore option.

What I meant to say was that your implementation of the validateOptions is perfectly fine and I don't want to override, but rather I just want to control the value of .ignore option.

Please take a look at my change, the idea is to keep the same default behavior (by default it will ignore :hidden) of the method and just enable the possibility to control the .ignore option.

Thank you as always for your time
Bye