### PR TITLE
Radio button now using prop("checked", true/false) instead of attr("checked")

### DIFF
--- a/Serenity.Script.UI/Editor/RadioButtonEditor.cs
+++ b/Serenity.Script.UI/Editor/RadioButtonEditor.cs
@@ -78,13 +78,13 @@ namespace Serenity
                     var inputs = this.element.Find("input");
                     var checks = inputs.Filter(":checked");
                     if (checks.Length > 0)
-                        (checks[0] as dynamic).@checked = false;
+                        checks.Property("checked", false);
 
                     if (!string.IsNullOrEmpty(value))
                     {
                         checks = inputs.Filter("[value=" + value + "]");
                         if (checks.Length > 0)
-                            (checks[0] as dynamic).@checked = true;
+                            checks.Property("checked", true);
                     }
                 }
             }


### PR DESCRIPTION
@volkanceylan 
I have made a correction in RadioButtonEditor.
Setting now use prop() instead of attr() becouse is more recommended, and with attr() I have a malfunction.
