### PR TITLE
Giving a hint to fix "Specified cast is not valid." exception.

### DIFF
--- a/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
+++ b/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
@@ -82,7 +82,7 @@ namespace Serenity.Data
                     _setValue(row, (TValue)value);
                 } catch (InvalidCastException ex)
                 {
-                    throw new Exception($"Invalid cast exception while trying to set the value of {this.Name} field on {row.GetType().Name} as object.", ex);
+                    throw new InvalidCastException($"Invalid cast exception while trying to set the value of {this.Name} field on {row.GetType().Name} as object.", ex);
                 }
             }
 

--- a/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
+++ b/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
@@ -80,9 +80,9 @@ namespace Serenity.Data
                 try
                 {
                     _setValue(row, (TValue)value);
-                } catch(Exception ex)
+                } catch (InvalidCastException ex)
                 {
-                    throw new Exception($"{ex.Message} This exception occured in Row: {row.GetType().Name}, Field: {this.Name}", ex);
+                    throw new Exception($"Invalid cast exception while trying to set the value of {this.Name} field on {row.GetType().Name} as object.", ex);
                 }
             }
 

--- a/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
+++ b/Serenity.Data.Entity/FieldTypes/GenericValueField.cs
@@ -76,7 +76,15 @@ namespace Serenity.Data
             if (value == null)
                 _setValue(row, null);
             else
-                _setValue(row, (TValue)value);
+            {
+                try
+                {
+                    _setValue(row, (TValue)value);
+                } catch(Exception ex)
+                {
+                    throw new Exception($"{ex.Message} This exception occured in Row: {row.GetType().Name}, Field: {this.Name}", ex);
+                }
+            }
 
             if (row.tracking)
                 row.FieldAssignedValue(this);


### PR DESCRIPTION
this is very useful to identify (culprit!) field on row. specially if the row has so many fields.