### PR TITLE
DateEditor setting minDate, maxDate

### DIFF
--- a/Serenity.Script.UI/Editor/DateEditor.cs
+++ b/Serenity.Script.UI/Editor/DateEditor.cs
@@ -30,8 +30,7 @@ namespace Serenity
                 YearRange = YearRange ?? "-100:+50"
             });
 
-            input.Bind("keyup." + this.uniqueName, e =>
-            {
+            input.Bind("keyup." + this.uniqueName, e => {
                 if (e.Which == 32 && !ReadOnly)
                 {
                     if (this.ValueAsDate != JsDate.Today)
@@ -81,8 +80,8 @@ namespace Serenity
             int x;
             if (val.Length >= 6 && Int32.TryParse(val, out x))
             {
-                input.Value(val.Substr(0, 2) + Q.Culture.DateSeparator +
-                    val.Substr(2, 2) + Q.Culture.DateSeparator +
+                input.Value(val.Substr(0, 2) + Q.Culture.DateSeparator + 
+                    val.Substr(2, 2) + Q.Culture.DateSeparator + 
                     val.Substr(4));
             }
 
@@ -164,7 +163,7 @@ namespace Serenity
                         }
                         else
                             break;
-                    default:
+                    default: 
                         return;
                 }
 
@@ -186,7 +185,7 @@ namespace Serenity
                             return;
                         break;
                     case 3:
-                        if (!IsNumeric(val[0]) ||
+                        if (!IsNumeric(val[0]) || 
                             val[1].ToString() != Q.Culture.DateSeparator ||
                             val[2] <= '1')
                             return;
@@ -234,7 +233,7 @@ namespace Serenity
             get
             {
                 string value = this.element.GetValue().Trim();
-
+                
                 if (value != null && value.Length == 0)
                     return null;
 
@@ -339,7 +338,7 @@ namespace Serenity
                 return MinValue == "1753-01-01" &&
                     MaxValue == "9999-12-31";
             }
-            set
+            set 
             {
                 if (value)
                 {

--- a/Serenity.Script.UI/Editor/DateEditor.cs
+++ b/Serenity.Script.UI/Editor/DateEditor.cs
@@ -30,7 +30,8 @@ namespace Serenity
                 YearRange = YearRange ?? "-100:+50"
             });
 
-            input.Bind("keyup." + this.uniqueName, e => {
+            input.Bind("keyup." + this.uniqueName, e =>
+            {
                 if (e.Which == 32 && !ReadOnly)
                 {
                     if (this.ValueAsDate != JsDate.Today)
@@ -80,8 +81,8 @@ namespace Serenity
             int x;
             if (val.Length >= 6 && Int32.TryParse(val, out x))
             {
-                input.Value(val.Substr(0, 2) + Q.Culture.DateSeparator + 
-                    val.Substr(2, 2) + Q.Culture.DateSeparator + 
+                input.Value(val.Substr(0, 2) + Q.Culture.DateSeparator +
+                    val.Substr(2, 2) + Q.Culture.DateSeparator +
                     val.Substr(4));
             }
 
@@ -163,7 +164,7 @@ namespace Serenity
                         }
                         else
                             break;
-                    default: 
+                    default:
                         return;
                 }
 
@@ -185,7 +186,7 @@ namespace Serenity
                             return;
                         break;
                     case 3:
-                        if (!IsNumeric(val[0]) || 
+                        if (!IsNumeric(val[0]) ||
                             val[1].ToString() != Q.Culture.DateSeparator ||
                             val[2] <= '1')
                             return;
@@ -233,7 +234,7 @@ namespace Serenity
             get
             {
                 string value = this.element.GetValue().Trim();
-                
+
                 if (value != null && value.Length == 0)
                     return null;
 
@@ -313,13 +314,21 @@ namespace Serenity
         public JsDate MinDate
         {
             get { return Q.ParseISODateTime(MinValue); }
-            set { MinValue = Q.FormatDate(value, "yyyy-MM-dd"); }
+            set
+            {
+                MinValue = Q.FormatDate(value, "yyyy-MM-dd");
+                Element.DatePicker().MinDate = value;
+            }
         }
 
         public JsDate MaxDate
         {
             get { return Q.ParseISODateTime(MaxValue); }
-            set { MaxValue = Q.FormatDate(value, "yyyy-MM-dd"); }
+            set
+            {
+                MaxValue = Q.FormatDate(value, "yyyy-MM-dd");
+                Element.DatePicker().MaxDate = value;
+            }
         }
 
         [Option]
@@ -330,7 +339,7 @@ namespace Serenity
                 return MinValue == "1753-01-01" &&
                     MaxValue == "9999-12-31";
             }
-            set 
+            set
             {
                 if (value)
                 {


### PR DESCRIPTION
If we set `MinDate = '2018-01-10'` of a DateEditor

Before|After
-|-
![before](https://user-images.githubusercontent.com/16621563/34465801-8aa73680-eee9-11e7-87ea-a4039eb06f38.png) | ![after](https://user-images.githubusercontent.com/16621563/34465804-92e69f70-eee9-11e7-9e7b-534a50aec7dd.png)
