### PR TITLE
setting min/max value of start/end widget of DateFiltering

### DIFF
--- a/Serenity.Script.UI/Grid/DataGrid.cs
+++ b/Serenity.Script.UI/Grid/DataGrid.cs
@@ -1185,10 +1185,13 @@ namespace Serenity
                     args.Active = active1 || active2;
 
                     if (active1)
+                    {
+                        end.MinDate = args.Widget.ValueAsDate;
                         args.Request.Criteria &= new Criteria(args.Field) >= args.Widget.Value;
-
+                    }
                     if (active2)
                     {
+                        args.Widget.MaxDate = end.ValueAsDate;
                         var next = new JsDate(end.ValueAsDate.ValueOf());
                         next.SetDate(next.GetDate() + 1);
                         args.Request.Criteria &= new Criteria(args.Field) < Q.FormatDate(next, "yyyy-MM-dd");


### PR DESCRIPTION
When we select startDate then endDate should not be less than startDate or vice-versa.

![datefiltering](https://user-images.githubusercontent.com/16621563/34465874-910883a6-eeeb-11e7-9af3-fb2ae4f5b6e3.png)

> This pull is dependent on previous one.