### PR TITLE
Change icon for alert dialog (replace thumbdown by exclamation sign)

### DIFF
--- a/Serenity.Web/Style/serenity.dialogs.less
+++ b/Serenity.Web/Style/serenity.dialogs.less
@@ -114,7 +114,7 @@ div.s-Toolbar .s-PopupToolButton .button-outer > span > b {
 }
 
 .s-AlertDialog .ui-dialog-content:before {
-    content: "\f165";
+    content: "\f06a";
     color: #dd4b39;
 }
 


### PR DESCRIPTION
I think thumb-down mean "bad", I don't think it fits for alert message so I change it to exclamation-sign icon

<a href="https://ibb.co/eYewBb"><img src="https://preview.ibb.co/n0BnHG/changes.png" alt="changes" border="0"></a>
  