### PR TITLE
[Bug] persisting sort order, Update DataGrid.ts

### DIFF
--- a/Serenity.TypeScript.CoreLib/UI/DataGrid/DataGrid.ts
+++ b/Serenity.TypeScript.CoreLib/UI/DataGrid/DataGrid.ts
@@ -1525,7 +1525,7 @@
 
                     if (flags.sortColumns !== false) {
                         var sort = Q.indexOf(sortColumns, (ss as any).mkdel({ column: column }, function(x: Slick.ColumnSort) {
-                            return x.columnId !== this.column.$.id;
+                            return x.columnId === this.column.$.id;
                         }));
 
                         p.sort = ((sort >= 0) ? ((sortColumns[sort].sortAsc !== false) ? (sort + 1) : (-sort - 1)) : 0);


### PR DESCRIPTION
Persisting the sort order is broken in 3.4.0, this seems to be to cause