### PR TITLE
DeleteNonPresentLines for MasterDetailRelation

### DIFF
--- a/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
+++ b/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
@@ -12,11 +12,13 @@ namespace Serenity.Data.Mapping
 
             this.ForeignKey = foreignKey;
             this.CheckChangesOnUpdate = true;
+            this.DeleteNonPresentLines = true;
             this.ColumnSelection = ColumnSelection.List;
         }
 
         public string ForeignKey { get; private set; }
         public bool CheckChangesOnUpdate { get; set; }
+        public bool DeleteNonPresentLines { get; set; }
         public ColumnSelection ColumnSelection { get; set; }
         public string IncludeColumns { get; set; }
         public string FilterField { get; set; }

--- a/Serenity.Services/RequestHandlers/IntegratedFeatures/MasterDetail/MasterDetailRelationBehavior.cs
+++ b/Serenity.Services/RequestHandlers/IntegratedFeatures/MasterDetail/MasterDetailRelationBehavior.cs
@@ -258,7 +258,7 @@ namespace Serenity.Services
 
             var rowIdField = (Field)((row as IIdRow).IdField);
 
-            if (newList.Count == 0)
+            if (newList.Count == 0 && attr.DeleteNonPresentLines)
             {
                 foreach (Row entity in oldList)
                     DeleteDetail(uow, rowIdField.AsObject(entity));
@@ -279,12 +279,15 @@ namespace Serenity.Services
                     newById[idStr] = item;
             }
 
-            foreach (Row item in oldList)
+            if (attr.DeleteNonPresentLines)
             {
-                var id = rowIdField.AsObject(item);
-                var idStr = AsString(id);
-                if (!newById.ContainsKey(idStr))
-                    DeleteDetail(uow, id);
+                foreach (Row item in oldList)
+                {
+                    var id = rowIdField.AsObject(item);
+                    var idStr = AsString(id);
+                    if (!newById.ContainsKey(idStr))
+                        DeleteDetail(uow, id);
+                }
             }
 
             foreach (Row item in newList)


### PR DESCRIPTION
Hi @volkanceylan 

In case that in master detail list are shown only some rows (by pre-filter in repository), when entity are updated all non showed rows are deleted. 

I added DeleteNonPresentLines to make possible to decide if keep non present lines.


