### PR TITLE
Masterdetail different idfield

### DIFF
--- a/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
+++ b/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
@@ -23,6 +23,11 @@ namespace Serenity.Data.Mapping
         public object FilterValue { get; set; }
 
         /// <summary>
+        /// Optional: override the default behaviour and use a different id field (i.e. from a unique constraint)
+        /// </summary>
+        public string AltIdField { get; set; }
+
+        /// <summary>
         /// Forces deletion of linking row records even if master record uses soft delete.
         /// If false (default) this doesn't delete linking records, as master record might be undeleted.
         /// </summary>

--- a/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
+++ b/Serenity.Data/Mapping/MasterDetailRelationAttribute.cs
@@ -25,7 +25,7 @@ namespace Serenity.Data.Mapping
         /// <summary>
         /// Optional: override the default behaviour and use a different id field (i.e. from a unique constraint)
         /// </summary>
-        public string AltIdField { get; set; }
+        public string MasterKeyField { get; set; }
 
         /// <summary>
         /// Forces deletion of linking row records even if master record uses soft delete.


### PR DESCRIPTION
Sometimes, it makes sense not to use the primary key field of the master table for a master detail relationship. For example if you have a field with a unique constraint on the master table (like a alphanumeric order number in the northwind orders table) and want the master detail relationship to use that field.

This extension of the MasterDetailRelationBehaviour adds this feature.