### PR TITLE
Fix typo in CloseQuote

### DIFF
--- a/Serenity.Data/Dialects/SqlServer2000Dialect.cs
+++ b/Serenity.Data/Dialects/SqlServer2000Dialect.cs
@@ -34,7 +34,7 @@ namespace Serenity.Data
         {
             get
             {
-                return '[';
+                return ']';
             }
         }
 


### PR DESCRIPTION
Or maybe remove OpenQuote/CloseQuote? Seems not to be used at all, otherwise this bug would have been noticed earlier.