### PR TITLE
To fix the UI issue of date input box.

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/Editors/DateTimeEditor.ts
+++ b/Serenity.Scripts/CoreLib/UI/Editors/DateTimeEditor.ts
@@ -3,7 +3,7 @@
     import Option = Serenity.Decorators.option
 
     @Decorators.registerEditor('Serenity.DateTimeEditor', [IStringValue, IReadOnly])
-    @Decorators.element('<input/>')
+    @Decorators.element('<input type="text"/>')
     export class DateTimeEditor extends Widget<DateTimeEditorOptions> implements IStringValue, IReadOnly {
 
         private minValue: string;


### PR DESCRIPTION
The "@Decorators.element('<input/>')" should be changed to "@Decorators.element('<input type="text"/>') to avoid the input text box of date without round corner border.