### PR TITLE
checked null in GetName() and GetText() Enum extentions

### DIFF
--- a/Serenity.Core/Helpers/EnumMapper.cs
+++ b/Serenity.Core/Helpers/EnumMapper.cs
@@ -90,11 +90,17 @@ namespace Serenity
 
         public static string GetName(this Enum value)
         {
+            if (value == null)
+                return String.Empty;
+
             return System.Enum.GetName(value.GetType(), value);
         }
 
         public static string GetText(this Enum value)
         {
+            if (value == null)
+                return String.Empty;
+
             return FormatEnum(value.GetType(), value);
         }
 


### PR DESCRIPTION
`item.SomeEnumField.GetText()` is throwing null ref. exception

this PR is a patch to this situation.
