### PR TITLE
Update MainWindow.xaml.cs

### DIFF
--- a/Serenity.CodeGenerator.Net45/MainWindow.xaml.cs
+++ b/Serenity.CodeGenerator.Net45/MainWindow.xaml.cs
@@ -461,7 +461,8 @@ namespace Serenity.CodeGenerator
                 MessageBox.Show("Identifier for table " + noIdentifier.FullName + " is empty!");
                 return;
             };
-
+            //BUG: if user changed CustomTemplates via the config UI, it was not transfered to  Templates.TemplatePath
+            Templates.TemplatePath = this.CustomTemplates;
             foreach (var table in tables)
             {
                 try


### PR DESCRIPTION
if user changed CustomTemplates via the config UI of sergen.exe, it was not transfered to  Templates.TemplatePath

I think regardless this.CustomTemplates  is null or not, it should be transfered to Templates.TemplatePath.

Maybe it can be done in other place.  But it's missing now. It's a bug.