### PR TITLE
ability to custom COMMAND Timeout

### DIFF
--- a/Serenity.Data/Connections/WrappedConnection.cs
+++ b/Serenity.Data/Connections/WrappedConnection.cs
@@ -8,6 +8,7 @@ namespace Serenity.Data
         private bool openedOnce;
         private WrappedTransaction currentTransaction;
         private ISqlDialect dialect;
+        private int? customCommandTimeout;
 
         public WrappedConnection(IDbConnection actualConnection, ISqlDialect dialect)
         {
@@ -129,6 +130,18 @@ namespace Serenity.Data
         public void Dispose()
         {
             actualConnection.Dispose();
+        }
+
+        public int? CustomCommandTimeout
+        {
+            get
+            {
+                return customCommandTimeout;
+            }
+            set
+            {
+                this.customCommandTimeout = value;
+            }
         }
     }
 }

--- a/Serenity.Data/SqlHelpers/SqlHelper.cs
+++ b/Serenity.Data/SqlHelpers/SqlHelper.cs
@@ -233,7 +233,18 @@
             if (connection == null)
                 throw new ArgumentNullException("connection");
 
+            int? customCommandTimeout = null;
+
+            if (connection is WrappedConnection)
+            {
+                customCommandTimeout = (connection as WrappedConnection).CustomCommandTimeout;
+            }
+
             IDbCommand command = connection.CreateCommand();
+            if (customCommandTimeout != null)
+            {
+                command.CommandTimeout = (int)customCommandTimeout;
+            }
 
             // TODO: find a workaround in new Dapper
 #if !COREFX


### PR DESCRIPTION
Due to issue at here: https://github.com/volkanceylan/Serenity/issues/4250

Currently, command timeout is 30 seconds and fixed, with some large queries it can cause timeout issue

**How to use in Endpoint.cs**
```csharp
if (connection is WrappedConnection customConnection)
{
    // custom COMMAND timeout
    customConnection.CustomCommandTimeout = 5;   // <=======================

    // we can custom connection timeout if we want
    var sqlConnStringBuilder = new SqlConnectionStringBuilder(connection.ConnectionString) { ConnectTimeout = 7 };
    connection.ConnectionString = sqlConnStringBuilder.ConnectionString;

    return new MyRepository().List(customConnection, request);
}
else
{
    return new MyRepository().List(connection, request);
}
```
