### PR TITLE
FileUploadEditor: MaxSize works only for Images

### DIFF
--- a/Serenity.Web/Upload/UploadProcessor.cs
+++ b/Serenity.Web/Upload/UploadProcessor.cs
@@ -102,8 +102,8 @@ namespace Serenity.Web
                         fileContent.Seek(0, SeekOrigin.Begin);
                         using (FileStream fs = new FileStream(FilePath, FileMode.Create))
                         {
-                            FileSize = fs.Length;
                             fileContent.CopyTo(fs);
+                            FileSize = fs.Length;
                         }
 #else
                         success = ProcessImageStream(fileContent, extension);
@@ -115,8 +115,8 @@ namespace Serenity.Web
                         fileContent.Seek(0, SeekOrigin.Begin);
                         using (FileStream fs = new FileStream(FilePath, FileMode.Create))
                         {
-                            FileSize = fs.Length;
                             fileContent.CopyTo(fs);
+                            FileSize = fs.Length;
                         }
                         success = true;
                     }


### PR DESCRIPTION
It doesn't make much sense to read the Length property before anything is copied to the FileStream ;-)