### PR TITLE
fileSizeDisplay inconsistent

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/Helpers/UploadHelper.ts
+++ b/Serenity.Scripts/CoreLib/UI/Helpers/UploadHelper.ts
@@ -90,8 +90,8 @@
         export function fileSizeDisplay(bytes: number): string {
             var byteSize = (ss as any).round(bytes * 100 / 1024) * 0.01;
             var suffix = 'KB';
-            if (byteSize > 1000) {
-                byteSize = (ss as any).round(byteSize * 0.001 * 100) * 0.01;
+            if (byteSize >= 1024) {
+                byteSize = (ss as any).round(byteSize * 100 / 1024) * 0.01;
                 suffix = 'MB';
             }
             var sizeParts = byteSize.toString().split(String.fromCharCode(46));


### PR DESCRIPTION
KB and MB display was inconsistent.

Before change:
1 KB = 1024 bytes, 1 MB = 1000*1024 bytes

After change (windows displays sizes this way):
1 KB = 1024 bytes, 1 MB = 1024*1024 bytes

(The other option would be 1 KB = 1000 bytes, 1 MB = 1000*1000 bytes)