### PR TITLE
Wait cursor not removed after ColumnPicker quick search

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/DataGrid/ColumnPickerDialog.ts
+++ b/Serenity.Scripts/CoreLib/UI/DataGrid/ColumnPickerDialog.ts
@@ -28,6 +28,7 @@ namespace Serenity {
                         $(e).toggle(!txt || Select2.util.stripDiacritics(
                             $(e).text().toLowerCase()).indexOf(txt) >= 0);
                     });
+                    done && done(true);
                 }
             });
 


### PR DESCRIPTION
It seems that a call to done() is missing in onSearch