### PR TITLE
[BUGFIX]: sort order not correctly restored

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/DataGrid/DataGrid.ts
+++ b/Serenity.Scripts/CoreLib/UI/DataGrid/DataGrid.ts
@@ -1190,7 +1190,11 @@
                         });
 
                         sortColumns.sort(function (a, b) {
-                            return a.sort - b.sort;
+                            // sort holds two informations:
+                            // absoulte value: order of sorting
+                            // sign: positive = ascending, negativ = descending
+                            // so we have to compare absolute values here
+                            return Math.abs(a.sort) - Math.abs(b.sort);
                         });
 
                         for (var $t5 = 0; $t5 < sortColumns.length; $t5++) {


### PR DESCRIPTION
If a grid is sorted by two (or more) columns, and the secondary sort order is descending, sorting is not restored correctly.