### PR TITLE
added ISqlQueryToString interface

### DIFF
--- a/Serenity.Data/Dialects/ISqlQueryToString.cs
+++ b/Serenity.Data/Dialects/ISqlQueryToString.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The method which will call inside SqlQuery.ToString() method
         /// </summary>
-        string SqlQueryToString(SqlQuery sqlQuery);
+        string SqlQueryToString(SqlQuery sqlQuery, SqlQueryElements queryElements);
 
     }
 }

--- a/Serenity.Data/Dialects/ISqlQueryToString.cs
+++ b/Serenity.Data/Dialects/ISqlQueryToString.cs
@@ -1,0 +1,17 @@
+﻿namespace Serenity.Data
+{
+    /// <summary>
+    /// Abstraction for SQL Query ToString(), e.g. dialect with custom ToString() method.
+    /// </summary>
+    public interface ISqlQueryToString
+    {
+        /// <summary>
+        /// The method which will call inside SqlQuery.ToString() method
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the server supports OFFSET FETCH; otherwise, <c>false</c>.
+        /// </value>
+        string SqlQueryToString(SqlQuery sqlQuery);
+
+    }
+}

--- a/Serenity.Data/Dialects/ISqlQueryToString.cs
+++ b/Serenity.Data/Dialects/ISqlQueryToString.cs
@@ -8,9 +8,6 @@
         /// <summary>
         /// The method which will call inside SqlQuery.ToString() method
         /// </summary>
-        /// <value>
-        ///   <c>true</c> if the server supports OFFSET FETCH; otherwise, <c>false</c>.
-        /// </value>
         string SqlQueryToString(SqlQuery sqlQuery);
 
     }

--- a/Serenity.Data/FluentSql/SqlQueryElements.cs
+++ b/Serenity.Data/FluentSql/SqlQueryElements.cs
@@ -28,6 +28,7 @@
         public List<object> Into { get; set; } = new List<object>();
         public SqlQuery UnionQuery { get; set; }
         public SqlUnionType UnionType { get; set; }
+        public QueryWithParams Parent { get; set; }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     }

--- a/Serenity.Data/FluentSql/SqlQueryElements.cs
+++ b/Serenity.Data/FluentSql/SqlQueryElements.cs
@@ -1,0 +1,34 @@
+﻿namespace Serenity.Data
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// SQL query elements which is basically used for generating custor query string outside the SqlQuery class. eg: inside dialect
+    /// </summary>
+    public partial class SqlQueryElements
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public Dictionary<string, string> AliasExpressions { get; set; }
+        public Dictionary<string, IHaveJoins> AliasWithJoins { get; set; }
+        public List<SqlQuery.Column> Columns { get; set; }
+        public bool CountRecords { get; set; }
+        public bool Distinct { get; set; }
+        public StringBuilder From { get; set; }
+        public StringBuilder Having { get; set; }
+        public StringBuilder GroupBy { get; set; }
+        public List<string> OrderBy { get; set; }
+        public string ForXml { get; set; }
+        public string ForJson { get; set; }
+        public int Skip { get; set; }
+        public int Take { get; set; }
+        public StringBuilder Where { get; set; }
+        public int IntoIndex { get; set; } = -1;
+        public List<object> Into { get; set; } = new List<object>();
+        public SqlQuery UnionQuery { get; set; }
+        public SqlUnionType UnionType { get; set; }
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    }
+}

--- a/Serenity.Data/FluentSql/SqlQuery_ToString.cs
+++ b/Serenity.Data/FluentSql/SqlQuery_ToString.cs
@@ -12,8 +12,32 @@ namespace Serenity.Data
         ///   Formatted SELECT statement</returns>
         public override string ToString()
         {
-            if (dialect is ISqlQueryToString dialectWithToString) 
-                return dialectWithToString.SqlQueryToString(this);
+            if (dialect is ISqlQueryToString dialectWithToString)
+            {
+                var queryElements = new SqlQueryElements
+                {
+                    AliasExpressions = aliasExpressions,
+                    AliasWithJoins = aliasWithJoins,
+                    Columns = columns,
+                    CountRecords = countRecords,
+                    Distinct = distinct,
+                    ForJson = forJson,
+                    ForXml = forXml,
+                    From = from,
+                    GroupBy = groupBy,
+                    Having = having,
+                    Into = into,
+                    IntoIndex = intoIndex,
+                    OrderBy = orderBy,
+                    Skip = skip,
+                    Take = take,
+                    UnionQuery = unionQuery,
+                    UnionType = unionType,
+                    Where = where
+                };
+
+                return dialectWithToString.SqlQueryToString(this, queryElements);
+            }
 
             var sb = new StringBuilder();
 

--- a/Serenity.Data/FluentSql/SqlQuery_ToString.cs
+++ b/Serenity.Data/FluentSql/SqlQuery_ToString.cs
@@ -33,7 +33,8 @@ namespace Serenity.Data
                     Take = take,
                     UnionQuery = unionQuery,
                     UnionType = unionType,
-                    Where = where
+                    Where = where,
+                    Parent = parent
                 };
 
                 return dialectWithToString.SqlQueryToString(this, queryElements);

--- a/Serenity.Data/FluentSql/SqlQuery_ToString.cs
+++ b/Serenity.Data/FluentSql/SqlQuery_ToString.cs
@@ -12,6 +12,9 @@ namespace Serenity.Data
         ///   Formatted SELECT statement</returns>
         public override string ToString()
         {
+            if (dialect is ISqlQueryToString dialectWithToString) 
+                return dialectWithToString.SqlQueryToString(this);
+
             var sb = new StringBuilder();
 
             if (unionQuery != null)


### PR DESCRIPTION
added ISqlQueryToString interface to provide a hook for custom query string builder for dialects. eg. Oracle12c etc.

Instead of modifying complex logic inside the SqlQuery.ToString() method this PR will allow writing dialect-specific ToString implementation like the following
```
    public class Oracle12cDialect : OracleDialect, ISqlQueryToString
    {
        public static new readonly ISqlDialect Instance = new Oracle12cDialect();

        public string SqlQueryToString(SqlQuery sqlQuery, SqlQueryElements queryElements)
        {
            throw new NotImplementedException();
        }
    }
```