### PR TITLE
EntityDialog: Allow cloning when readOnly

### DIFF
--- a/Serenity.Scripts/CoreLib/UI/Dialogs/EntityDialog.ts
+++ b/Serenity.Scripts/CoreLib/UI/Dialogs/EntityDialog.ts
@@ -931,7 +931,7 @@
                     });
                 },
                 visible: () => false,
-                disabled: () => !this.hasInsertPermission() || this.readOnly
+                disabled: () => !this.hasInsertPermission()
             });
 
             return list;


### PR DESCRIPTION
IMHO, an entity should still be clone-able, even if the source entity is read only.